### PR TITLE
cancel the network stream if AsyncStream is cancelled,

### DIFF
--- a/Sources/OpenAIKit/Helpers/OpenAIKitNetwork.swift
+++ b/Sources/OpenAIKit/Helpers/OpenAIKitNetwork.swift
@@ -153,6 +153,10 @@ public final class OpenAIKitNetwork {
 				}
 
 				stream.startStream()
+                
+                continuation.onTermination = { @Sendable _ in
+                    stream.stopStream()
+                }
 			}
 		}
 	}


### PR DESCRIPTION
I love that your package supports stopping streams. That seems to be a major gap in other packages. Thank you.

I'm using the AsyncThrowing stream in a Task, and noticed that if I cancel the Task, then the cancellation automatically propagates to the  stream.

This was actually a problem as it meant I didn't get a chance to check for Task.isCancelled - and stop the networkStream manually.

Then I realised that this can be done automatically using onTermination of the continuation.

Thoughts?
